### PR TITLE
Adding remote tag lister

### DIFF
--- a/utils/git-remote-versions.sh
+++ b/utils/git-remote-versions.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "Finding latest tags available..."
+
+sources=$(grep "source.*github.com/bitrockteam" ./*tf | sed -E "s@^.*github.com\/bitrockteam\/([^?/\"]+).*\$@\1@" | uniq)
+
+while read source
+do
+  tag=$(git ls-remote --tags "git@github.com:bitrockteam/$source" | tail -n1 | awk '{ print $2;}' | tr -d '^{}')
+  echo "$source = $tag"
+
+done <<< "$sources"


### PR DESCRIPTION
Example:

```shell
caravan-infra-gcp [$] 
➜ ../caravan/utils/git-remote-versions.sh
Finding latest tags available...
caravan-bootstrap = refs/tags/v0.2.0
caravan-acme-le = refs/tags/v0.0.1
caravan-cloudinit = refs/tags/v0.1.4

```